### PR TITLE
Defer incompatible tooling majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,17 @@ updates:
           - minor
           - patch
     ignore:
+      # Keep development types and release tooling aligned with the declared
+      # Node 22.0 support floor. Revisit these when that floor changes.
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@release-it/conventional-changelog"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: release-it
+        update-types:
+          - version-update:semver-major
       - dependency-name: typescript
         update-types:
           - version-update:semver-major

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here.
 
 ### Changed
 
-- Refreshed the private competitive benchmark dependencies and measured comparison tables, clearing its audit findings and adding Dependabot coverage for the benchmark lockfile.
+- Refreshed the private competitive benchmark dependencies and measured comparison tables, clearing its audit findings, adding Dependabot coverage for the benchmark lockfile, and documenting the Node-floor policy for major development-tool upgrades.
 
 ## 2.1.2 - 2026-07-31
 


### PR DESCRIPTION
## What changed

- defer major updates for Node type declarations, TypeScript, and release tooling
- document that the exclusions should be revisited with the declared Node support floor

## Why

The current majors either model a newer Node runtime than the supported Node 22 floor or require a newer Node 22 minor for development. Keeping these proposals out of the active queue preserves the explicit compatibility policy while minor and patch updates continue normally.

## Verification

- `npm run lint`
- Dependabot configuration remains valid YAML and existing minor/patch update groups are unchanged
