### PR TITLE
Finalize v2.1.4 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here.
 
-## Unreleased
+## 2.1.4 - 2026-08-26
 
 ### Added
 


### PR DESCRIPTION
## Summary

- replace the pending changelog heading with the exact v2.1.4 entry required by the trusted-publish workflow

## Verification

- release-it patch dry-run recommends 2.1.4
- publish workflow checks for `## 2.1.4 ` before npm publishing
